### PR TITLE
Fix layer freezing

### DIFF
--- a/bert_nli.py
+++ b/bert_nli.py
@@ -53,6 +53,9 @@ class BertNLIModel(nn.Module):
             if self.gpu: self.to('cuda')
 
     def reinit(self, layer_num = 4):
+        """Reinitialise parameters of last N layers and freeze all others"""
+        for _, pp in self.bert.named_parameters():
+            pp.requires_grad = False
         layer_idx = [self.num_hidden_layers-1-i for i in range(layer_num)]
         layer_names = ['encoder.layer.{}'.format(j) for j in layer_idx]
         for pn, pp in self.bert.named_parameters():

--- a/bert_nli.py
+++ b/bert_nli.py
@@ -57,7 +57,7 @@ class BertNLIModel(nn.Module):
         layer_names = ['encoder.layer.{}'.format(j) for j in layer_idx]
         for pn, pp in self.bert.named_parameters():
             if any([ln in pn for ln in layer_names]):
-                pp = torch.randn(pp.shape)*0.02
+                pp.data = torch.randn(pp.shape)*0.02
                 pp.requires_grad = True
 
 


### PR DESCRIPTION
Presently, `reinit()` has no effect on the model. Resolve this by freezing all parameters except for the last N layers. Additionally, fix the weight reinitialisation.

According to my tests, these changes drastically reduce the number of trainable parameters (from 180M to 15M for N=2 with `bert-base-multilingual-cased`). On the other hand, more training epochs are needed to achieve similar results as with the fullly trained model.