### PR TITLE
correct model selection conditions

### DIFF
--- a/bert_nli.py
+++ b/bert_nli.py
@@ -17,15 +17,15 @@ class BertNLIModel(nn.Module):
         super(BertNLIModel, self).__init__()
         self.bert_type = bert_type
 
-        if 'bert-base' in bert_type:
+        if 'albert' in bert_type:
+            self.bert = AlbertModel.from_pretrained(bert_type)
+            self.tokenizer = AlbertTokenizer.from_pretrained(bert_type)
+        elif 'bert-base' in bert_type:
             self.bert = BertModel.from_pretrained('bert-base-uncased')
             self.tokenizer = BertTokenizer.from_pretrained('bert-base-uncased')
         elif 'bert-large' in bert_type:
             self.bert = BertModel.from_pretrained('bert-large-uncased')
             self.tokenizer = BertTokenizer.from_pretrained('bert-large-uncased')
-        elif 'albert' in bert_type:
-            self.bert = AlbertModel.from_pretrained(bert_type)
-            self.tokenizer = AlbertTokenizer.from_pretrained(bert_type)
         else:
             print('illegal bert type {}!'.format(bert_type))
 


### PR DESCRIPTION
Hi, here is minor correction for the model selection between BERT and ALBERT in the model class.  

In the previous code, when the model type was entered as "albert-base-v2" or "albert-large-v2", the method would load the corresponding BERT model instead of ALBERT since "bert-base" exists in the "albert-base-v2". 

This may explain why the reported ALBERT performance is so close to BERT. 